### PR TITLE
Explicit Cast To `jwt.SignOptions[expiresIn]` To Fix Tsc Compilation Error

### DIFF
--- a/insighthub-backend/src/controllers/auth_controller.ts
+++ b/insighthub-backend/src/controllers/auth_controller.ts
@@ -30,7 +30,7 @@ const generateTokens = (_id: string): { accessToken: string, refreshToken: strin
             random: random
         },
         config.token.access_token_secret(),
-        { expiresIn: config.token.token_expiration() });
+        { expiresIn: process.env.TOKEN_EXPIRATION as jwt.SignOptions['expiresIn'] });
 
     const refreshToken = jwt.sign(
         {
@@ -38,7 +38,7 @@ const generateTokens = (_id: string): { accessToken: string, refreshToken: strin
             random: random
         },
         config.token.access_token_secret(),
-        { expiresIn: config.token.refresh_token_expiration() });
+        { expiresIn: process.env.REFRESH_TOKEN_EXPIRATION as jwt.SignOptions['expiresIn'] });
 
     return { accessToken, refreshToken };
 }


### PR DESCRIPTION
Fixes an error of compiling with `tsc`:

![image](https://github.com/user-attachments/assets/2804b969-bca1-453e-9e66-396e569dbced)

Note that this PR has a small conflict with #24, but is easy to resolve.

In case #24 is merged, we should edit the whole `generateTokens` function to:

```js
const generateTokens = (_id: string): { accessToken: string, refreshToken: string } => {
    const random = Math.floor(Math.random() * 1000000);
    const accessToken = jwt.sign(
        {
            _id: _id,
            random: random
        },
        config.token.access_token_secret(),
        { expiresIn: process.env.TOKEN_EXPIRATION as jwt.SignOptions['expiresIn'] });

    const refreshToken = jwt.sign(
        {
            _id: _id,
            random: random
        },
        config.token.access_token_secret(),
        { expiresIn: process.env.REFRESH_TOKEN_EXPIRATION as jwt.SignOptions['expiresIn'] });

    return { accessToken, refreshToken };
}
```

