### PR TITLE
Move The Footer To Be After The Whole `App`

### DIFF
--- a/insighthub-frontend/src/App.tsx
+++ b/insighthub-frontend/src/App.tsx
@@ -4,18 +4,22 @@ import Login from './pages/Login';
 import Register from './pages/Register';
 import './App.css'
 import Dashboard from './pages/Dashboard';
+import Footer from './components/Footer';
 
 const App: React.FC = () => {
   return (
-    <Router>
-      <Routes>
-        <Route path="/" element={<Login />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/register" element={<Register />} />
-        <Route path="/dashboard" element={<Dashboard />} />
-        <Route path="*" element={<Navigate to="/" />} />
-      </Routes>
-    </Router>
+    <div>
+      <Router>
+        <Routes>
+          <Route path="/" element={<Login />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/register" element={<Register />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="*" element={<Navigate to="/" />} />
+        </Routes>
+      </Router>
+      <Footer/>
+    </div>
   );
 };
 

--- a/insighthub-frontend/src/pages/Login.tsx
+++ b/insighthub-frontend/src/pages/Login.tsx
@@ -4,7 +4,6 @@ import { Container, TextField, Button, Typography, Box, Paper, Link, Alert } fro
 import { Link as RouterLink, useNavigate } from 'react-router-dom';
 import './Login.css';
 import { config } from '../config';
-import Footer from '../components/Footer';
 
 const Login: React.FC = () => {
   const [email, setEmail] = useState('');
@@ -92,7 +91,6 @@ const Login: React.FC = () => {
           </Paper>
         </Box>
       </Container>
-      <Footer/>
     </div>
   );
 };

--- a/insighthub-frontend/src/pages/Register.tsx
+++ b/insighthub-frontend/src/pages/Register.tsx
@@ -4,7 +4,6 @@ import { Container, TextField, Button, Typography, Box, Paper, Link, Alert } fro
 import { Link as RouterLink, useNavigate } from 'react-router-dom';
 import './Register.css';
 import { config } from '../config';
-import Footer from '../components/Footer';
 
 const Register: React.FC = () => {
   const [username, setUsername] = useState('');
@@ -110,7 +109,6 @@ const Register: React.FC = () => {
           </Paper>
         </Box>
       </Container>
-      <Footer/>
     </div>
   );
 };


### PR DESCRIPTION
Enhancements for #27 

Implements https://github.com/Lina0Elman/InsightHub/pull/27#issuecomment-2677851026

Set the footer to be after the whole `App` so all the pages would be affected with the footer, and no further maintenance would be needed.