### PR TITLE
Support Uploading & Downloading Images In The Server

### DIFF
--- a/insighthub-backend/.gitignore
+++ b/insighthub-backend/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 dist/
 package-lock.json
 openssl-secret.txt
+resources
 
 # Environment
 .env

--- a/insighthub-backend/package.json
+++ b/insighthub-backend/package.json
@@ -32,6 +32,7 @@
     "js-yaml": "^4.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.8.2",
+    "multer": "^1.4.5-lts.1",
     "supertest": "^7.0.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1"

--- a/insighthub-backend/src/app.ts
+++ b/insighthub-backend/src/app.ts
@@ -5,6 +5,7 @@ import bodyParser from 'body-parser';
 import posts_routes from './routes/posts_routes';
 import comments_routes from './routes/comments_routes';
 import auth_routes from './routes/auth_routes';
+import resource_routes from './routes/resources_routes';
 import swaggerUi from 'swagger-ui-express';
 import loadOpenApiFile from './openapi/openapi_loader';
 import cors from 'cors';
@@ -35,5 +36,6 @@ app.use('/swagger', swaggerUi.serve, swaggerUi.setup(loadOpenApiFile()));
 app.use('/post', posts_routes);
 app.use('/comment', comments_routes);
 app.use('/auth', auth_routes);
+app.use('/resource', resource_routes);
 
 export default app;

--- a/insighthub-backend/src/config.ts
+++ b/insighthub-backend/src/config.ts
@@ -13,6 +13,6 @@ export const config = {
         access_token_secret: () => process.env.ACCESS_TOKEN_SECRET || 'secret'
     },
     resources: {
-        directoryPath: () => 'resources'
+        imagesDirectoryPath: () => 'resources/images'
     }
 }

--- a/insighthub-backend/src/config.ts
+++ b/insighthub-backend/src/config.ts
@@ -11,5 +11,8 @@ export const config = {
         refresh_token_expiration: () => process.env.REFRESH_TOKEN_EXPIRATION || '3d',
         token_expiration: () => process.env.TOKEN_EXPIRATION || '100000s',
         access_token_secret: () => process.env.ACCESS_TOKEN_SECRET || 'secret'
+    },
+    resources: {
+        directoryPath: () => 'resources'
     }
 }

--- a/insighthub-backend/src/config.ts
+++ b/insighthub-backend/src/config.ts
@@ -13,6 +13,7 @@ export const config = {
         access_token_secret: () => process.env.ACCESS_TOKEN_SECRET || 'secret'
     },
     resources: {
-        imagesDirectoryPath: () => 'resources/images'
+        imagesDirectoryPath: () => 'resources/images',
+        imageMaxSize: () => 10 * 1024 * 1024 // Max file size: 10MB
     }
 }

--- a/insighthub-backend/src/controllers/resources_controller.ts
+++ b/insighthub-backend/src/controllers/resources_controller.ts
@@ -7,14 +7,14 @@ import { uploadImage } from '../services/resources_service';
 const createImageResource = async (req, res) => {
     const upload = uploadImage.single('file');
     upload(req, res, error => {
-        if (!req.file) {
-            return res.status(400).send('No file uploaded.');
-        }
         if (error instanceof multer.MulterError) {
             return res.status(400).send(error.message);
         } else if (error instanceof TypeError) {
             return res.status(400).send(error.message);
         } else if (error) {
+            if (!req.file) {
+                return res.status(400).send('No file uploaded.');
+            }
             return res.status(500).send("Internal Server Error");
         }
 

--- a/insighthub-backend/src/controllers/resources_controller.ts
+++ b/insighthub-backend/src/controllers/resources_controller.ts
@@ -3,9 +3,9 @@ import { config } from '../config';
 import fs from 'fs';
 import path from 'path';
 import { uploadImage } from '../services/resources_service';
-const upload = uploadImage.single('file');
 
 const createImageResource = async (req, res) => {
+    const upload = uploadImage.single('file');
     upload(req, res, error => {
         if (!req.file) {
             return res.status(400).send('No file uploaded.');

--- a/insighthub-backend/src/controllers/resources_controller.ts
+++ b/insighthub-backend/src/controllers/resources_controller.ts
@@ -11,10 +11,9 @@ const createImageResource = async (req, res) => {
             return res.status(400).send(error.message);
         } else if (error instanceof TypeError) {
             return res.status(400).send(error.message);
+        } else if (!req.file) {
+            return res.status(400).send('No file uploaded.');
         } else if (error) {
-            if (!req.file) {
-                return res.status(400).send('No file uploaded.');
-            }
             return res.status(500).send("Internal Server Error");
         }
 

--- a/insighthub-backend/src/controllers/resources_controller.ts
+++ b/insighthub-backend/src/controllers/resources_controller.ts
@@ -1,0 +1,18 @@
+import multer from 'multer';
+
+const createImageResource = async (req, res) => {
+    if (!req.file) {
+        return res.status(400).send('No file uploaded.');
+    }
+
+    try {
+        res.status(201).send({ imagePath: req.file.path });
+    } catch (error) {
+        if (error instanceof multer.MulterError) {
+            return res.status(400).send(error.message);
+        }
+        res.status(500).send("Internal Server Error");
+    }
+};
+
+export default { createImageResource };

--- a/insighthub-backend/src/controllers/resources_controller.ts
+++ b/insighthub-backend/src/controllers/resources_controller.ts
@@ -2,20 +2,24 @@ import multer from 'multer';
 import { config } from '../config';
 import fs from 'fs';
 import path from 'path';
+import { uploadImage } from '../services/resources_service';
+const upload = uploadImage.single('file');
 
 const createImageResource = async (req, res) => {
-    if (!req.file) {
-        return res.status(400).send('No file uploaded.');
-    }
-
-    try {
-        res.status(201).send(req.file.filename);
-    } catch (error) {
+    upload(req, res, error => {
+        if (!req.file) {
+            return res.status(400).send('No file uploaded.');
+        }
         if (error instanceof multer.MulterError) {
             return res.status(400).send(error.message);
+        } else if (error instanceof TypeError) {
+            return res.status(400).send(error.message);
+        } else if (error) {
+            return res.status(500).send("Internal Server Error");
         }
-        res.status(500).send("Internal Server Error");
-    }
+
+        return res.status(201).send(req.file.filename);
+    })
 };
 
 const getImageResource = async (req, res) => {

--- a/insighthub-backend/src/controllers/resources_controller.ts
+++ b/insighthub-backend/src/controllers/resources_controller.ts
@@ -1,4 +1,7 @@
 import multer from 'multer';
+import { config } from '../config';
+import fs from 'fs';
+import path from 'path';
 
 const createImageResource = async (req, res) => {
     if (!req.file) {
@@ -6,7 +9,7 @@ const createImageResource = async (req, res) => {
     }
 
     try {
-        res.status(201).send({ imagePath: req.file.path });
+        res.status(201).send(req.file.filename);
     } catch (error) {
         if (error instanceof multer.MulterError) {
             return res.status(400).send(error.message);
@@ -15,4 +18,19 @@ const createImageResource = async (req, res) => {
     }
 };
 
-export default { createImageResource };
+const getImageResource = async (req, res) => {
+    try {
+        const { filename } = req.params;
+        const imagePath = path.resolve(config.resources.imagesDirectoryPath(), filename);
+
+        if (!fs.existsSync(imagePath)) {
+            return res.status(404).send('Image not found');
+        }
+
+        res.sendFile(imagePath);
+    } catch (error) {
+        res.status(500).send('Internal Server Error');
+    }
+};
+
+export default { createImageResource, getImageResource };

--- a/insighthub-backend/src/openapi/swagger.yaml
+++ b/insighthub-backend/src/openapi/swagger.yaml
@@ -11,6 +11,8 @@ tags:
     description: Operations related to comments on posts
   - name: Authentication
     description: Operations related to authentication tokens
+  - name: Resources
+    description: Operations related to uploading & downloading resources
 
 paths:
   # Post Routes
@@ -368,6 +370,38 @@ paths:
           description: Successfully logged out
         '401':
           description: Invalid refresh token
+
+  /resource/image:
+    post:
+      tags:
+        - Resources
+      summary: Upload an image
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        '201':
+          description: Image uploaded successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  imagePath:
+                    type: string
+        '400':
+          description: Bad request - No file uploaded
+        '500':
+          description: Internal server error
 
 components:
   schemas:

--- a/insighthub-backend/src/openapi/swagger.yaml
+++ b/insighthub-backend/src/openapi/swagger.yaml
@@ -392,14 +392,39 @@ paths:
         '201':
           description: Image uploaded successfully
           content:
-            application/json:
+            text/plain:
               schema:
-                type: object
-                properties:
-                  imagePath:
-                    type: string
+                description: The name of the uploaded file
+                type: string                
         '400':
           description: Bad request - No file uploaded
+        '500':
+          description: Internal server error
+
+  /resource/image/{filename}:
+    get:
+      tags:
+        - Resources
+      summary: Retrieve an image
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: filename
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The name of the image file to retrieve
+      responses:
+        '200':
+          description: Image retrieved successfully
+          content:
+            image/*:
+              schema:
+                type: string
+                format: binary
+        '404':
+          description: Image not found
         '500':
           description: Internal server error
 

--- a/insighthub-backend/src/openapi/swagger.yaml
+++ b/insighthub-backend/src/openapi/swagger.yaml
@@ -397,7 +397,16 @@ paths:
                 description: The name of the uploaded file
                 type: string                
         '400':
-          description: Bad request - No file uploaded
+          description: Bad request
+          content:
+            text/plain:
+              examples:
+                fileTooLarge:
+                  value: "File too large"
+                invalidFileType:
+                  value: "Invalid file type. Only images are allowed: /jpeg|jpg|png|gif/"
+                noFileUploaded:
+                  value: "No file uploaded"
         '500':
           description: Internal server error
 

--- a/insighthub-backend/src/routes/resources_routes.ts
+++ b/insighthub-backend/src/routes/resources_routes.ts
@@ -1,0 +1,11 @@
+
+import express from 'express';
+import Resource from '../controllers/resources_controller';
+import  { authMiddleware } from '../controllers/auth_controller';
+import { uploadImage } from '../services/resources_service';
+
+const router = express.Router();
+
+router.post('/image', authMiddleware, uploadImage.single('file'), Resource.createImageResource);
+
+export default router;

--- a/insighthub-backend/src/routes/resources_routes.ts
+++ b/insighthub-backend/src/routes/resources_routes.ts
@@ -7,5 +7,6 @@ import { uploadImage } from '../services/resources_service';
 const router = express.Router();
 
 router.post('/image', authMiddleware, uploadImage.single('file'), Resource.createImageResource);
+router.get('/image/:filename', authMiddleware, Resource.getImageResource);
 
 export default router;

--- a/insighthub-backend/src/routes/resources_routes.ts
+++ b/insighthub-backend/src/routes/resources_routes.ts
@@ -2,11 +2,10 @@
 import express from 'express';
 import Resource from '../controllers/resources_controller';
 import  { authMiddleware } from '../controllers/auth_controller';
-import { uploadImage } from '../services/resources_service';
 
 const router = express.Router();
 
-router.post('/image', authMiddleware, uploadImage.single('file'), Resource.createImageResource);
+router.post('/image', authMiddleware, Resource.createImageResource);
 router.get('/image/:filename', authMiddleware, Resource.getImageResource);
 
 export default router;

--- a/insighthub-backend/src/routes/resources_routes.ts
+++ b/insighthub-backend/src/routes/resources_routes.ts
@@ -6,6 +6,6 @@ import  { authMiddleware } from '../controllers/auth_controller';
 const router = express.Router();
 
 router.post('/image', authMiddleware, Resource.createImageResource);
-router.get('/image/:filename', authMiddleware, Resource.getImageResource);
+router.get('/image/:filename', Resource.getImageResource);
 
 export default router;

--- a/insighthub-backend/src/services/resources_service.ts
+++ b/insighthub-backend/src/services/resources_service.ts
@@ -9,7 +9,7 @@ const createImagesStorage = () => {
     // Ensure the directory exists
     const imagesResourcesDir = config.resources.imagesDirectoryPath();
     if (!fs.existsSync(imagesResourcesDir)) {
-        fs.mkdirSync(imagesResourcesDir);
+        fs.mkdirSync(imagesResourcesDir, { recursive: true });
     }
 
     const imagesStorage = multer.diskStorage({

--- a/insighthub-backend/src/services/resources_service.ts
+++ b/insighthub-backend/src/services/resources_service.ts
@@ -4,28 +4,29 @@ import path from 'path';
 import { randomUUID } from 'crypto';
 import fs from 'fs';
 
-
-// Ensure the directory exists
-const resourcesDir = config.resources.directoryPath();
-if (!fs.existsSync(resourcesDir)) {
-    fs.mkdirSync(resourcesDir);
-}
-
-const storage = multer.diskStorage({
-    destination: (req, file, cb) => {
-        cb(null, `${resourcesDir}/`);
-    },
-    filename: (req, file, cb) => {
-        const ext = path.extname(file.originalname);
-        const id = randomUUID();
-        cb(null, id + ext);
+const createImagesStorage = () => {
+    
+    // Ensure the directory exists
+    const imagesResourcesDir = config.resources.imagesDirectoryPath();
+    if (!fs.existsSync(imagesResourcesDir)) {
+        fs.mkdirSync(imagesResourcesDir);
     }
-});
 
-const uploadImage = multer({
-        storage: storage,
+    const imagesStorage = multer.diskStorage({
+        destination: (req, file, cb) => {
+            cb(null, `${imagesResourcesDir}/`);
+        },
+        filename: (req, file, cb) => {
+            const ext = path.extname(file.originalname);
+            const id = randomUUID();
+            cb(null, id + ext);
+        }
+    });
+
+    const uploadImage = multer({
+        storage: imagesStorage,
         limits: {
-            fileSize: 10 * 1024 * 1024  // Max file size: 10MB
+            fileSize: 10 * 1024 * 1024 // Max file size: 10MB
         },
         fileFilter: (req, file, cb) => {
             const allowedTypes = /jpeg|jpg|png|gif/;
@@ -39,5 +40,10 @@ const uploadImage = multer({
             }
         }
     });
+
+    return uploadImage;
+};
+
+const uploadImage = createImagesStorage();
 
 export { uploadImage };

--- a/insighthub-backend/src/services/resources_service.ts
+++ b/insighthub-backend/src/services/resources_service.ts
@@ -36,7 +36,7 @@ const createImagesStorage = () => {
             if (extname && mimetype) {
                 return cb(null, true);
             } else {
-                cb(new Error('Invalid file type. Only images are allowed.'));
+                cb(new TypeError(`Invalid file type. Only images are allowed: ${allowedTypes}.`));
             }
         }
     });

--- a/insighthub-backend/src/services/resources_service.ts
+++ b/insighthub-backend/src/services/resources_service.ts
@@ -36,7 +36,7 @@ const createImagesStorage = () => {
             if (extname && mimetype) {
                 return cb(null, true);
             } else {
-                cb(new TypeError(`Invalid file type. Only images are allowed: ${allowedTypes}.`));
+                return cb(new TypeError(`Invalid file type. Only images are allowed: ${allowedTypes}.`));
             }
         }
     });

--- a/insighthub-backend/src/services/resources_service.ts
+++ b/insighthub-backend/src/services/resources_service.ts
@@ -26,7 +26,7 @@ const createImagesStorage = () => {
     const uploadImage = multer({
         storage: imagesStorage,
         limits: {
-            fileSize: 10 * 1024 * 1024 // Max file size: 10MB
+            fileSize: config.resources.imageMaxSize()
         },
         fileFilter: (req, file, cb) => {
             const allowedTypes = /jpeg|jpg|png|gif/;

--- a/insighthub-backend/src/services/resources_service.ts
+++ b/insighthub-backend/src/services/resources_service.ts
@@ -1,0 +1,43 @@
+import { config } from '../config';
+import multer from 'multer';
+import path from 'path';
+import { randomUUID } from 'crypto';
+import fs from 'fs';
+
+
+// Ensure the directory exists
+const resourcesDir = config.resources.directoryPath();
+if (!fs.existsSync(resourcesDir)) {
+    fs.mkdirSync(resourcesDir);
+}
+
+const storage = multer.diskStorage({
+    destination: (req, file, cb) => {
+        cb(null, `${resourcesDir}/`);
+    },
+    filename: (req, file, cb) => {
+        const ext = path.extname(file.originalname);
+        const id = randomUUID();
+        cb(null, id + ext);
+    }
+});
+
+const uploadImage = multer({
+        storage: storage,
+        limits: {
+            fileSize: 10 * 1024 * 1024  // Max file size: 10MB
+        },
+        fileFilter: (req, file, cb) => {
+            const allowedTypes = /jpeg|jpg|png|gif/;
+            const extname = allowedTypes.test(path.extname(file.originalname).toLowerCase());
+            const mimetype = allowedTypes.test(file.mimetype);
+
+            if (extname && mimetype) {
+                return cb(null, true);
+            } else {
+                cb(new Error('Invalid file type. Only images are allowed.'));
+            }
+        }
+    });
+
+export { uploadImage };

--- a/insighthub-backend/src/services/resources_service.ts
+++ b/insighthub-backend/src/services/resources_service.ts
@@ -36,7 +36,7 @@ const createImagesStorage = () => {
             if (extname && mimetype) {
                 return cb(null, true);
             } else {
-                return cb(new TypeError(`Invalid file type. Only images are allowed: ${allowedTypes}.`));
+                return cb(new TypeError(`Invalid file type. Only images are allowed: ${allowedTypes}`));
             }
         }
     });


### PR DESCRIPTION
Closes #17 

## Changes

- Added POST creation of images, by adding a new "Resources Controller".
- In the "Resources Controller", add GET image by image path, that will download the image.
- Handled file assertions:
   - Assert that the uploaded file extension is an image extension - i.e. `.png`, `.jpeg`, `.jpg`, `.gif`.
   - Assert the file is not too large - limit to 10MB.

## Leading Note

In the frontend, we need to parse the `content`s of `Post`s and `Comment`s to find out if they contain a path to an image, and if so, to uploaded & download images.
