### PR TITLE
Fix Bcrypt Package To BcryptJS

### DIFF
--- a/insighthub-backend/package.json
+++ b/insighthub-backend/package.json
@@ -20,7 +20,8 @@
   },
   "homepage": "https://github.com/Lina0Elman/InsightHub#readme",
   "dependencies": {
-    "bcrypt": "^5.1.1",
+    "axios": "^1.8.3",
+    "bcryptjs": "^3.0.2",
     "body-parser": "^1.20.3",
     "cors": "^2.8.5",
     "cross-env": "^7.0.3",
@@ -39,8 +40,7 @@
     "socket.io": "^4.8.1",
     "supertest": "^7.0.0",
     "swagger-jsdoc": "^6.2.8",
-    "swagger-ui-express": "^5.0.1",
-    "axios": "^1.8.3"
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.26.0",

--- a/insighthub-backend/src/services/users_service.ts
+++ b/insighthub-backend/src/services/users_service.ts
@@ -1,6 +1,6 @@
 import { UserModel } from '../models/user_model';
 import {IUser, UserData} from 'types/user_types';
-import bcrypt from 'bcrypt';
+import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import { RefreshTokenModel } from '../models/refresh_token_model';
 import {config} from '../config/config'


### PR DESCRIPTION
Replace `bcrypt` package with `bcryptjs` to fix the error:

```
PS I:\Tal\Code\js\InsightHub\insighthub-backend> npm run dev

> ex@1.0.0 dev
> nodemon ./src/server.ts

[nodemon] 3.1.9
[nodemon] to restart at any time, enter `rs`
[nodemon] watching path(s): *.*
[nodemon] watching extensions: ts,json
[nodemon] starting `ts-node ./src/server.ts`
Error: \\?\I:\Tal\Code\js\InsightHub\insighthub-backend\node_modules\bcrypt\lib\binding\napi-v3\bcrypt_lib.node is not a valid Win32 application.
\\?\I:\Tal\Code\js\InsightHub\insighthub-backend\node_modules\bcrypt\lib\binding\napi-v3\bcrypt_lib.node
    at Object..node (node:internal/modules/cjs/loader:1725:18)
    at Module.load (node:internal/modules/cjs/loader:1313:32)
    at Function._load (node:internal/modules/cjs/loader:1123:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:217:24)
    at Module.require (node:internal/modules/cjs/loader:1335:12)
    at require (node:internal/modules/helpers:136:16)
    at Object.<anonymous> (I:\Tal\Code\js\InsightHub\insighthub-backend\node_modules\bcrypt\bcrypt.js:6:16)
    at Module._compile (node:internal/modules/cjs/loader:1562:14)
    at node:internal/modules/cjs/loader:1699:10 {
  code: 'ERR_DLOPEN_FAILED'
}
[nodemon] app crashed - waiting for file changes before starting...
```